### PR TITLE
Fixed issue with incorrect published and updated dates when consuming an Atom feed

### DIFF
--- a/modules/cbfeeds/models/util/ReaderUtil.cfc
+++ b/modules/cbfeeds/models/util/ReaderUtil.cfc
@@ -221,6 +221,8 @@ Description :
 			if(StructKeyExists(arguments.xmlRoot,"lastBuildDate"))
 				createdDate = arguments.xmlRoot.lastBuildDate.xmlText;
 			// atom 1
+			else if(StructKeyExists(arguments.xmlRoot,"published"))
+				createdDate = arguments.xmlRoot.published.xmlText;
 			else if(StructKeyExists(arguments.xmlRoot,"updated"))
 				createdDate = arguments.xmlRoot.updated.xmlText;
 			return createdDate;
@@ -302,10 +304,10 @@ Description :
 			else if(StructKeyExists(arguments.xmlRoot,"dc:date"))
 				updatedDate = arguments.xmlRoot["dc:date"].xmlText;
 			// atom 1
-			else if(StructKeyExists(arguments.xmlRoot,"published"))
-				updatedDate = arguments.xmlRoot.published.xmlText;
 			else if(StructKeyExists(arguments.xmlRoot,"updated"))
 				updatedDate = arguments.xmlRoot.updated.xmlText;
+			else if(StructKeyExists(arguments.xmlRoot,"published"))
+				updatedDate = arguments.xmlRoot.published.xmlText;
 			return updatedDate;
 		</cfscript>
 	</cffunction>


### PR DESCRIPTION
I noticed when consuming an Atom feed such as a YouTube feed, that the item updated and published dates were swapped.   Upon looking at the code I discovered that the function findCreatedDate() was looking at the updated date only.  I modified it to look for the published date first and then the updated date.   Similarly the function findUpdatedDate() was looking at the published date first.  I modified it to look for the updated date first and then the published date.